### PR TITLE
add: missing date.format

### DIFF
--- a/Xresources/i3xrocks
+++ b/Xresources/i3xrocks
@@ -5,3 +5,4 @@ i3xrocks.critical.color:    color_red
 i3xrocks.error.color:       color_orange
 i3xrocks.warning:           color_yellow
 i3xrocks.nominal:           color_base0
+i3xrocks.date.format:       + %m-%d %H:%M


### PR DESCRIPTION
don’t know if this was omitted by purpose but i think the date format would actually be nice to already be provided in this xresources file