### PR TITLE
fix broken style theme name

### DIFF
--- a/Xresources/root
+++ b/Xresources/root
@@ -17,7 +17,7 @@
 ! -- Styles - Theme
 ! NOTE: GTK theme and icon packages may need to be installed when enabling themes.
 ! Uncomment one and only one of the following theme definitions:
-!#include "/etc/regolith/styles/theme-regolith-solarized"
+!#include "/etc/regolith/styles/theme-regolith"
 !#include "/etc/regolith/styles/theme-ubuntu-dark"
 #include "/etc/regolith/styles/theme-nordic"
 


### PR DESCRIPTION
There is no theme-regolith-solarized in the styles folder anymore. It is called theme-regolith now. I spent a lot of time figuring this out after the update