### PR TITLE
Balance workspace name by adding space at end

### DIFF
--- a/Xresources/i3-wm
+++ b/Xresources/i3-wm
@@ -54,7 +54,7 @@ i3-wm.gaps.outer.size: i3wm_gaps_outer_size
 
 #define glyph_font QUOTE(typeface_bar_glyph)
 
-#define WORKSPACE_NAME(INDEX, FONT, COLOR, GLYPH) INDEX:<span font_desc=FONT> INDEX </span><span foreground=COLOR>GLYPH</span><span font_desc=FONT> </span>
+#define WORKSPACE_NAME(INDEX, FONT, COLOR, GLYPH) INDEX:<span> </span><span font_desc=FONT>INDEX </span><span foreground=COLOR>GLYPH</span><span> </span>
 
 i3-wm.workspace.01.name: WORKSPACE_NAME(1, glyph_font, QUOTE(color_blue), glyph)
 i3-wm.workspace.02.name: WORKSPACE_NAME(2, glyph_font, QUOTE(color_cyan), glyph)

--- a/Xresources/i3-wm
+++ b/Xresources/i3-wm
@@ -54,7 +54,7 @@ i3-wm.gaps.outer.size: i3wm_gaps_outer_size
 
 #define glyph_font QUOTE(typeface_bar_glyph)
 
-#define WORKSPACE_NAME(INDEX, FONT, COLOR, GLYPH) INDEX:<span font_desc=FONT> INDEX </span><span foreground=COLOR>GLYPH</span>
+#define WORKSPACE_NAME(INDEX, FONT, COLOR, GLYPH) INDEX:<span font_desc=FONT> INDEX </span><span foreground=COLOR>GLYPH</span><span font_desc=FONT> </span>
 
 i3-wm.workspace.01.name: WORKSPACE_NAME(1, glyph_font, QUOTE(color_blue), glyph)
 i3-wm.workspace.02.name: WORKSPACE_NAME(2, glyph_font, QUOTE(color_cyan), glyph)


### PR DESCRIPTION
This attempts to fix the visual imbalance in workspace names (issue #19) by adding a space to the end of the workspace name as well.

In Cahuella, the fix looks like this:

Before:

![before](https://i.imgur.com/Y7fy2Xl.png)

After:

![after](https://i.imgur.com/I1Gej7Y.png)

This does not affect looks using a different macro (such as Lascaille, which has its own i3-wm file).