### PR TITLE
Fix on background file path

### DIFF
--- a/pop-os/theme
+++ b/pop-os/theme
@@ -1,6 +1,6 @@
 #define gtk_theme           Pop-dark
 #define icon_theme          Pop
-#define desktop_wallpaper   /usr/share/backgrounds/pop/kate-hazen-unleash-your-robot.png 
+#define desktop_wallpaper   /usr/share/backgrounds/kate-hazen-unleash-your-robot-blue.png 
 #define rofi_theme          /etc/regolith/styles/pop-os/rofi.rasi
 #define theme_terminal_scrollbar never
 


### PR DESCRIPTION
I installed all the themes on my machine and got "triggered" when the pop-os' default wallpaper was the same as the regolith one, then configuring the theme specs I found the problem, a small mistake on the file path at the `theme` file. I read the issues #26 and #25 and decided to contribute to the community work. Thx, guys. 