### PR TITLE
ubuntu: Fix color_base2 incomplete hex code

### DIFF
--- a/ubuntu/color
+++ b/ubuntu/color
@@ -5,7 +5,7 @@
 #define color_base00   #666666
 #define color_base0    #FFFFFF
 #define color_base1    #F7F7F7
-#define color_base2    #CCC
+#define color_base2    #CDCDCD
 #define color_base3    #878787
 #define color_yellow   #f99b11
 #define color_orange   #E95420


### PR DESCRIPTION
This incomplete hex code comes from a typo in https://github.com/ubuntu/yaru/blob/master/gtk/src/default/gtk-3.20/_palette.scss for $silk palette. There are some hints in the ubuntu/yaru repository telling that color_base2 or $silk RGB hex code should be #CDCDCD, for instance in `gtksourceview/src/light.xml.in` and `gtksourceview/src/dark.xml.in`:
`<color name="silk" value="#CDCDCD" />`