### PR TITLE
add launcher icon for ubuntu style

### DIFF
--- a/ubuntu/typeface
+++ b/ubuntu/typeface
@@ -45,3 +45,4 @@
 #define typeface_bar_glyph_error 
 
 #define typeface_bar_glyph_next_workspace 
+#define typeface_bar_glyph_app_launcher 


### PR DESCRIPTION
The ubuntu style was missing the definition of `typeface_bar_glyph_app_launcher`.
As a result `typeface_bar_glyph_app_launcher` was displayed in the status bar in plain text.

Adding the definition to the `typeface` file, analogous to the other styles, fixes the problem.